### PR TITLE
New operations and support for oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ return mailshake.campaigns.list({
 
 > Don't forget to change `my-api-key` to your own key.
 
+
+### OAuth support
+mailshake-node has hooks to support most any OAuth library. You can either customize the request with `customizeRequest` or outright replace how the request is made with `overrideCreateRequest`.
+
+```javascript
+let mailshake = require('mailshake-node')({
+  customizeRequest(options) => {
+    // options.headers.authorization = [...oauth header...]
+    return options;
+  }),
+
+  // or
+
+  overrideCreateRequest(options, callbackFn) => {
+    return https(options, callbackFn);
+  })
+});
+```
+
 ### Operations
 _See our [docs](http://api-docs.mailshake.com/) for details._
 
@@ -39,6 +58,7 @@ _See our [docs](http://api-docs.mailshake.com/) for details._
 - campaigns.unpause
 - campaigns.export
 - campaigns.exportStatus
+- campaigns.create
 - leads.list
 - leads.get
 - leads.close
@@ -61,6 +81,7 @@ _See our [docs](http://api-docs.mailshake.com/) for details._
 - activity.opens
 - activity.replies
 - activity.sent
+- senders.list
 
 ### Paging
 When a request accepts paging parameters, a call to get the next page is conveniently attached to your result.

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,8 @@
 class Config {
   // baseUrl;
   // apiKey;
+  // customizeRequest (options: any) => any
+  // overrideCreateRequest (options: any, callbackFn: (res => void)) => any
 
   constructor (arg1, arg2) {
     this.baseUrl = `https://api.mailshake.com/2017-04-01`;

--- a/lib/mailshake.js
+++ b/lib/mailshake.js
@@ -64,6 +64,7 @@ let Mailshake = (arg1, arg2) => {
     'campaigns/unpause',
     'campaigns/export',
     'campaigns/export-status',
+    'campaigns/create',
     'leads/list',
     'leads/get',
     'leads/close',
@@ -85,7 +86,8 @@ let Mailshake = (arg1, arg2) => {
     'activity/lead-status-changes',
     'activity/opens',
     'activity/replies',
-    'activity/sent'
+    'activity/sent',
+    'senders/list'
   ]);
   instance.push.fetch = (url) => {
     let request = new Request(config);

--- a/lib/request.js
+++ b/lib/request.js
@@ -33,26 +33,38 @@ class Request {
   executeRaw (fullUrl, args) {
     this.prepare(fullUrl, args);
     this.addAuthentication();
-    return new Promise((resolve, reject) => {
-      let req = this.transport.request(this.requestOptions, (res) => {
-        this.handleResponse(res)
-          .then(resolve)
-          .catch(reject);
-      });
-      this.response = new Response(fullUrl, args, this.config);
-      req.on('error', reject);
-      req.write(this.body);
-      req.end();
-    })
-      .then(result => {
-        return this.response.parse(null, result);
-      })
+    if (this.config.customizeRequest) {
+      this.requestOptions = this.config.customizeRequest(this.requestOptions);
+    }
+    this.response = new Response(fullUrl, args, this.config);
+    return this.createRawRequest()
+      .then(result => this.response.parse(null, result))
       .catch(err => {
         if (!this.response) {
           this.response = new Response(null);
         }
         return this.response.parse(err);
       });
+  }
+
+  createRawRequest () {
+    return new Promise((resolve, reject) => {
+      let req = this.initiateRawRequest(res => {
+        this.handleResponse(res)
+          .then(resolve)
+          .catch(reject);
+      });
+      req.on('error', reject);
+      req.write(this.body);
+      req.end();
+    });
+  }
+
+  initiateRawRequest (callbackFn) {
+    if (this.config.overrideCreateRequest) {
+      return this.config.overrideCreateRequest(this.requestOptions, callbackFn);
+    }
+    return this.transport.request(this.requestOptions, callbackFn);
   }
 
   prepare (fullUrl, args) {


### PR DESCRIPTION
- Use most any oauth package by being able to customize how requests are made
- Added `campaigns/create` and `senders/list`