### PR TITLE
fix: bump mocha version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "4"
-  - "6"
-  - "8"
+  - "10"
+  - "12"
+  - "14"
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -1,28 +1,36 @@
+# Mailshake Node.js Library
+
 [![Travis](https://travis-ci.org/mailshake/mailshake-node.svg?branch=master)](https://travis-ci.org/mailshake/mailshake-node)
 [![npm](https://img.shields.io/npm/v/mailshake-node.svg?maxAge=86400)](https://www.npmjs.com/package/mailshake-node)
 [![npm](https://img.shields.io/npm/dm/mailshake-node.svg?maxAge=86400)](https://www.npmjs.com/package/mailshake-node)
 [![npm](https://img.shields.io/npm/l/mailshake-node.svg?maxAge=2592000)](https://www.npmjs.com/package/mailshake-node)
 
-# mailshake-node
-This is a Node.js wrapper for the [Mailshake](https://mailshake.com) API. [View the docs here](http://api-docs.mailshake.com).
+This is the official Node.js library for the [Mailshake](https://mailshake.com)
+API. [View the docs here](http://api-docs.mailshake.com).
 
 ## Installation
+
 ```shell
 npm install mailshake-node
 ```
 
 ## Configuration and use
-Requiring the `mailshake-node` module takes your API key as an argument. Every operation returns a Promise. Errors from the calling API will populate the `code` property of the error contained by the operation's Promise.
+
+Requiring the `mailshake-node` module takes your API key as an argument. Every
+operation returns a Promise. Errors from the calling API will populate the
+`code` property of the error contained by the operation's Promise.
 
 ```javascript
-let mailshake = require('mailshake-node')('my-api-key');
-return mailshake.campaigns.list({
-  search: 'Venkman'
-})
-  .then(result => {
+const mailshake = require('mailshake-node')('my-api-key');
+
+return mailshake.campaigns
+  .list({
+    search: 'Venkman',
+  })
+  .then((result) => {
     console.log(JSON.stringify(result, null, 2));
   })
-  .catch(err => {
+  .catch((err) => {
     console.error(`${err.code}: ${err.message}`);
   });
 ```
@@ -31,10 +39,13 @@ return mailshake.campaigns.list({
 
 
 ### OAuth support
-mailshake-node has hooks to support most any OAuth library. You can either customize the request with `customizeRequest` or outright replace how the request is made with `overrideCreateRequest`.
+
+`mailshake-node` has hooks to support most any OAuth library. You can either
+customize the request with `customizeRequest` or outright replace how the
+request is made with `overrideCreateRequest`:
 
 ```javascript
-let mailshake = require('mailshake-node')({
+const mailshake = require('mailshake-node')({
   customizeRequest(options) => {
     // options.headers.authorization = [...oauth header...]
     return options;
@@ -44,12 +55,13 @@ let mailshake = require('mailshake-node')({
 
   overrideCreateRequest(options, callbackFn) => {
     return https(options, callbackFn);
-  })
+  }),
 });
 ```
 
 ### Operations
-_See our [docs](http://api-docs.mailshake.com/) for details._
+
+_See our official [API docs](http://api-docs.mailshake.com/) for details._
 
 - me
 - campaigns.list
@@ -84,42 +96,48 @@ _See our [docs](http://api-docs.mailshake.com/) for details._
 - senders.list
 
 ### Paging
-When a request accepts paging parameters, a call to get the next page is conveniently attached to your result.
 
-```javacsript
+When a request accepts paging parameters, a call to get the next page is
+conveniently attached to your result:
+
+```javascript
 mailshake.campaigns.list()
-  .then(result => {
+  .then((result) => {
     console.log(`Page 1: ${JSON.stringify(result, null, 2)}`);
     // Just call `next` to get the next page of data
     return result.next();
   })
-  .then(result => {
+  .then((result) => {
     console.log(`Page 2: ${JSON.stringify(result, null, 2)}`);
   });
 ```
 
 ## Push handling
-The Mailshake API lets you subscribe to real-time pushes so you can react in your app. To do this you tell Mailshake where to make HTTPS requests, your web server handles them, and sends back a `200` status. See [our docs on this](http://api-docs.mailshake.com/#Pushes) for more details.
+
+The Mailshake API lets you subscribe to real-time pushes so you can react in
+your app. To do this you tell Mailshake where to make HTTPS requests, your web
+server handles them, and sends back a `200` status. See [our docs on
+this](http://api-docs.mailshake.com/#Pushes) for more details.
 
 ### The easiest way to get started requires a few things:
 
 - use [`express`](https://expressjs.com/) as your web server
-- specify your external base url
+- specify your external base URL
 - specify a path to handle Mailshake pushes
 - specify a secret to secure your web hook
 
 ```javascript
-let express = require('express');
-let bodyParser = require('body-parser');
-let mailshake = require('mailshake-node')('my-api-key');
-let PushHandler = require('mailshake-node').PushHandler;
+const express = require('express');
+const bodyParser = require('body-parser');
+const mailshake = require('mailshake-node')('my-api-key');
+const PushHandler = require('mailshake-node').PushHandler;
 
 // Initialize your express app, making sure to include bodyParser
-let app = express();
+const app = express();
 app.use(bodyParser.json({}));
 
 // Set up how your site is being hosted
-let handler = new PushHandler(mailshake, {
+const handler = new PushHandler(mailshake, {
   baseUrl: 'https://mailshake-test.ngrok.io',
   rootPath: 'pushes',
   secret: 'my-secret'
@@ -139,7 +157,7 @@ handler.on('pushError', err => {
 handler.hookExpress(app);
 
 // Start your server
-let port = 80;
+const port = 80;
 app.listen(port);
 console.log(`Listening on http://127.0.0.1:${port}`);
 ```
@@ -147,29 +165,37 @@ console.log(`Listening on http://127.0.0.1:${port}`);
 > Don't forget to change `my-api-key` to your own key.
 
 #### Subscribing to pushes
-Tell Mailshake what you want to listen for. This option will automatically format your subscription so that `PushHandler` can handle it.
+
+Tell Mailshake what you want to listen for. This option will automatically
+format your subscription so that `PushHandler` can handle it:
 
 ```javascript
-handler.subscribe('Clicked', { /* filter options */ })
-  .then(targetUrl => {
+handler
+  .subscribe('Clicked', {
+    // Filter options
+  })
+  .then((targetUrl) => {
     // Store targetUrl somewhere so you can unsubscribe later
   })
-  .catch(err => {
+  .catch((err) => {
     console.error(`${err.code}: ${err.stack}`);
   });
 ```
 
 #### Unsubscribing pushes
-When you're done, unsubscribe to stop receiving pushes.
+
+When you're done, `unsubscribe` to stop receiving pushes:
 
 ```javascript
-handler.unsubscribe(targetUrl)
-  .catch(err => {
+handler
+  .unsubscribe(targetUrl)
+  .catch((err) => {
     console.error(`${err.code}: ${err.stack}`);
   });
 ```
 
 ### Other details
+
 Mailshake will send your server a request like this:
 
 ```json
@@ -178,49 +204,60 @@ Mailshake will send your server a request like this:
 }
 ```
 
-Use the `resolvePush` operation to fetch the full data behind the push.
+Use the `resolvePush` operation to fetch the full data behind the push:
 
 ```javascript
-let resolvePush = require('mailshake-node').resolvePush;
-resolvePush(mailshake, { /* the object Mailshake sent your server */ })
-.then(result => {
-  console.log(JSON.stringify(result, null, 2));
+const resolvePush = require('mailshake-node').resolvePush;
+
+resolvePush(mailshake, {
+  // The object Mailshake sent your server
 })
-.catch(err => {
-  console.error(`${err.code}: ${err.message}`);
-});
+  .then((result) => {
+    console.log(JSON.stringify(result, null, 2));
+  })
+  .catch((err) => {
+    console.error(`${err.code}: ${err.message}`);
+  });
 ```
 
 ### A more hands-on approach when using `express`
-In case you can't or don't want to use our more complete `PushHandler` solution,  a `pushHandlerExpress` function is exposed on this module that encapsulates fetching the push's details and communicating back to Mailshake about the receipt being successful or not.
+
+In case you can't or don't want to use our more complete `PushHandler` solution,
+a `pushHandlerExpress` function is exposed on this module that encapsulates
+fetching the push's details and communicating back to Mailshake about the
+receipt being successful or not:
 
 ```javascript
-let pushHandlerExpress = require('mailshake-node').pushHandlerExpress;
-/*
- * NOTE:
- * Put this code inside the handler for your endpoint: */
+const pushHandlerExpress = require('mailshake-node').pushHandlerExpress;
+
+// NOTE: Put this code inside the handler for your endpoint:
 pushHandlerExpress(mailshake, receivedPush, response)
-  .then(result => {
+  .then((result) => {
     console.log(JSON.stringify(result, null, 2));
   })
-  .catch(err => {
+  .catch((err) => {
     console.error(`${err.code}: ${err.message}`);
   });
 ```
 
 ### Subscribing to pushes
-If you're not using [our main handler](#user-content-subscribing-to-pushes), you can subscribe to pushes like this:
+
+If you're not using [our main handler](#user-content-subscribing-to-pushes), you
+can subscribe to pushes like this:
 
 ```javascript
-return mailshake.push.create({
-  targetUrl: '[a unique url for this push to store for later so you can unsubscribe]',
-  event: 'Clicked',
-  filter: {  /* filter options */ }
-})
-  .then(result => {
+return mailshake.push
+  .create({
+    targetUrl: '[a unique url for this push to store for later so you can unsubscribe]',
+    event: 'Clicked',
+    filter: {
+      // Filter options
+    },
+  })
+  .then((result) => {
     // Nothing really to do here
   })
-  .catch(err => {
+  .catch((err) => {
     console.error(`${err.code}: ${err.message}`);
   });
 ```
@@ -228,22 +265,28 @@ return mailshake.push.create({
 Unsubscribe your subscriptions like this:
 
 ```javascript
-return mailshake.push.delete({
-  targetUrl: '[your unique url for the push to unsubscribe]'
-})
-  .then(result => {
+return mailshake.push
+  .delete({
+    targetUrl: '[your unique url for the push to unsubscribe]',
+  })
+  .then((result) => {
     // Nothing really to do here
   })
-  .catch(err => {
+  .catch((err) => {
     console.error(`${err.code}: ${err.message}`);
   });
 ```
 
 ## Contributions
+
 If you have improvements, please create a pull request for our consideration.
 
 ## Testing
-Our test suites for this module aren't yet part of the source. At the moment only one test is wired up here as a sanity check and to test connectivity. To use it create a local `CONFIG.json` file in the root directory of this repo like this:
+
+Our test suites for this module aren't yet part of the source. At the moment
+only one test is wired up here as a sanity check and to test connectivity. To
+use it create a local `CONFIG.json` file in the root directory of this repo like
+this:
 
 ```json
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mailshake-node",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1178,6 +1178,12 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
@@ -1391,9 +1397,9 @@
       }
     },
     "mocha": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.0.1.tgz",
-      "integrity": "sha512-vefaXfdYI8+Yo8nPZQQi0QO2o+5q9UIMX1jZ1XMmK3+4+CQjc7+B0hPdUeglXiTlr8IHMVRo63IhO9Mzt6fxOg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.1.tgz",
+      "integrity": "sha512-p7FuGlYH8t7gaiodlFreseLxEmxTgvyG9RgPHODFPySNhwUehu8NIb0vdSt3WFckSneswZ0Un5typYcWElk7HQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "4.1.1",
@@ -1412,7 +1418,7 @@
         "ms": "2.1.2",
         "object.assign": "4.1.0",
         "promise.allsettled": "1.0.2",
-        "serialize-javascript": "3.0.0",
+        "serialize-javascript": "4.0.0",
         "strip-json-comments": "3.0.1",
         "supports-color": "7.1.0",
         "which": "2.0.2",
@@ -1420,7 +1426,7 @@
         "workerpool": "6.0.0",
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.0"
+        "yargs-unparser": "1.6.1"
       },
       "dependencies": {
         "debug": {
@@ -1854,6 +1860,15 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -2053,10 +2068,13 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.0.0.tgz",
-      "integrity": "sha512-skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -2546,14 +2564,116 @@
       }
     },
     "yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
+      "integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
       "dev": true,
       "requires": {
+        "camelcase": "^5.3.1",
+        "decamelize": "^1.2.0",
         "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
+        "is-plain-obj": "^1.1.0",
+        "yargs": "^14.2.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "mailshake-node",
-  "version": "1.0.6",
-  "description": "Wrapper for the Mailshake API",
+  "version": "2.0.0",
+  "description": "Node.js Library for the Mailshake API",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=10.0.0"
   },
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "git+https://github.com/mailshake/mailshake-node.git"
   },
-  "author": "Colin Mathews",
+  "author": "Team Mailshake",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mailshake/mailshake-node/issues"
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "mocha": "^8.0.1",
+    "mocha": "^8.1.1",
     "semistandard": "^12.0.1"
   }
 }


### PR DESCRIPTION
Issue was actually with `serialize-javascript` which is a dependency of
`mocha`.

Related Advisory: https://github.com/advisories/GHSA-hxcc-f52p-wc94

Also changed the supported versions to the Node.js versions that are
still active and not at EOL and modernized/cleaned up the documentation
a bit.

Bumped the major version due to the major update to what versions of    
Node.js we're testing against.  