### PR TITLE
chore: bumped version, expanded licensing years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Colin Mathews
+Copyright (c) 2017, 2018, 2019, 2020, 2021 Mailshake, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailshake-node",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Node.js Library for the Mailshake API",
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
Had some security updates come through, bumping the version before
publishing.